### PR TITLE
ルーム一覧の取得とルーム作成およびルーム入室をgraphQLからwebsocketでできるように変更

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -98,8 +98,8 @@ export default function App(): ReactElement {
 
 export type RootStackParamList = {
   Home: undefined;
-  Room: { name: string };
-  CreateRoom: undefined;
+  Room: { roomname: string; endpoint: string };
+  CreateRoom: { endpoint: string };
   RoomList: undefined;
   EditDeck: undefined;
   Preferences: undefined;

--- a/App.tsx
+++ b/App.tsx
@@ -98,7 +98,7 @@ export default function App(): ReactElement {
 
 export type RootStackParamList = {
   Home: undefined;
-  Room: { id: number };
+  Room: { name: string };
   CreateRoom: undefined;
   RoomList: undefined;
   EditDeck: undefined;

--- a/App.tsx
+++ b/App.tsx
@@ -98,7 +98,7 @@ export default function App(): ReactElement {
 
 export type RootStackParamList = {
   Home: undefined;
-  Room: { roomname: string; endpoint: string };
+  Room: { roomid: number; endpoint: string };
   CreateRoom: { endpoint: string };
   RoomList: undefined;
   EditDeck: undefined;

--- a/App.tsx
+++ b/App.tsx
@@ -98,7 +98,7 @@ export default function App(): ReactElement {
 
 export type RootStackParamList = {
   Home: undefined;
-  Room: { roomid: number; endpoint: string };
+  Room: { roomid: string; endpoint: string };
   CreateRoom: { endpoint: string };
   RoomList: undefined;
   EditDeck: undefined;

--- a/src/screens/create-room/index.tsx
+++ b/src/screens/create-room/index.tsx
@@ -22,7 +22,6 @@ export default function CreateRoomScreen({
   // });
   const { endpoint } = route.params;
   const websocket = useRef<WebSocket | null>(null);
-  const [exists, setExists] = useState(false);
 
   useEffect(() => {
     websocket.current = new WebSocket(`ws://${endpoint}/ws`);
@@ -30,13 +29,10 @@ export default function CreateRoomScreen({
       if (event.data.startsWith("{")) {
         const json = JSON.parse(event.data);
         if (json.status === "ok") {
-          setExists(false);
           navigation.navigate("Room", {
             roomid: json.data.id,
             endpoint: endpoint,
           });
-        } else {
-          setExists(true);
         }
       }
     };
@@ -85,25 +81,13 @@ export default function CreateRoomScreen({
             <View>
               {errors.name && touched.name ? <Text>{errors.name}</Text> : null}
             </View>
-            {exists ? (
-              <Input
-                label="新規ルーム名"
-                value={values.name}
-                onChangeText={handleChange("name")}
-                onBlur={handleBlur("name")}
-                errorMessage="既に存在するルーム名です"
-                errorStyle={{ color: "red" }}
-                placeholder="ルーム名を入力してください"
-              />
-            ) : (
-              <Input
-                label="新規ルーム名"
-                value={values.name}
-                onChangeText={handleChange("name")}
-                onBlur={handleBlur("name")}
-                placeholder="ルーム名を入力してください"
-              />
-            )}
+            <Input
+              label="新規ルーム名"
+              value={values.name}
+              onChangeText={handleChange("name")}
+              onBlur={handleBlur("name")}
+              placeholder="ルーム名を入力してください"
+            />
             <Button
               title="Submit"
               onPress={() => handleSubmit()}

--- a/src/screens/create-room/index.tsx
+++ b/src/screens/create-room/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useRef, useState } from "react";
+import React, { ReactElement, useEffect, useRef } from "react";
 import { StyleSheet, View, Text } from "react-native";
 import { Button, Input } from "react-native-elements";
 import { StackNavigationProp } from "@react-navigation/stack";

--- a/src/screens/create-room/index.tsx
+++ b/src/screens/create-room/index.tsx
@@ -1,12 +1,6 @@
 import React, { ReactElement, useEffect, useRef } from "react";
-import {
-  StyleSheet,
-  View,
-  Text,
-  Button,
-  ScrollView,
-  TextInput,
-} from "react-native";
+import { StyleSheet, View, Text, ScrollView } from "react-native";
+import { Button, Input } from "react-native-elements";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { RouteProp } from "@react-navigation/native";
 import { RootStackParamList } from "../../../App";
@@ -82,17 +76,18 @@ export default function CreateRoomScreen({
                 {errors.name && touched.name ? (
                   <Text>{errors.name}</Text>
                 ) : null}
-                <TextInput
-                  value={values.name}
-                  onChangeText={handleChange("name")}
-                  onBlur={handleBlur("name")}
-                  placeholder="ルーム名を入力してください"
-                />
               </View>
+              <Input
+                value={values.name}
+                onChangeText={handleChange("name")}
+                onBlur={handleBlur("name")}
+                placeholder="ルーム名を入力してください"
+              />
               <Button
                 title="Submit"
                 onPress={() => handleSubmit()}
                 disabled={!isValid || isSubmitting}
+                style={styles.button}
               />
             </>
           )}
@@ -115,4 +110,5 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
+  button: { margin: 10 },
 });

--- a/src/screens/create-room/index.tsx
+++ b/src/screens/create-room/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useRef } from "react";
-import { StyleSheet, View, Text, ScrollView } from "react-native";
+import { StyleSheet, View, Text } from "react-native";
 import { Button, Input } from "react-native-elements";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { RouteProp } from "@react-navigation/native";

--- a/src/screens/create-room/index.tsx
+++ b/src/screens/create-room/index.tsx
@@ -43,6 +43,10 @@ export default function CreateRoomScreen({
     console.log(values);
     if (websocket.current != null) {
       websocket.current.send(`/join ${values.name}`);
+      navigation.navigate("Room", {
+        roomname: values.name,
+        endpoint: endpoint,
+      });
     }
   };
 

--- a/src/screens/create-room/index.tsx
+++ b/src/screens/create-room/index.tsx
@@ -51,49 +51,45 @@ export default function CreateRoomScreen({
       .required("ルーム名を入力してください"),
   });
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <View>
-        <Formik
-          initialValues={{
-            name: "",
-          }}
-          validateOnMount
-          validationSchema={schema}
-          onSubmit={(values) => onSubmit(values)}
-        >
-          {({
-            handleSubmit,
-            handleChange,
-            handleBlur,
-            isValid,
-            isSubmitting,
-            values,
-            errors,
-            touched,
-          }) => (
-            <>
-              <View>
-                {errors.name && touched.name ? (
-                  <Text>{errors.name}</Text>
-                ) : null}
-              </View>
-              <Input
-                value={values.name}
-                onChangeText={handleChange("name")}
-                onBlur={handleBlur("name")}
-                placeholder="ルーム名を入力してください"
-              />
-              <Button
-                title="Submit"
-                onPress={() => handleSubmit()}
-                disabled={!isValid || isSubmitting}
-                style={styles.button}
-              />
-            </>
-          )}
-        </Formik>
-      </View>
-    </ScrollView>
+    <View style={styles.container}>
+      <Formik
+        initialValues={{
+          name: "",
+        }}
+        validateOnMount
+        validationSchema={schema}
+        onSubmit={(values) => onSubmit(values)}
+      >
+        {({
+          handleSubmit,
+          handleChange,
+          handleBlur,
+          isValid,
+          isSubmitting,
+          values,
+          errors,
+          touched,
+        }) => (
+          <>
+            <View>
+              {errors.name && touched.name ? <Text>{errors.name}</Text> : null}
+            </View>
+            <Input
+              value={values.name}
+              onChangeText={handleChange("name")}
+              onBlur={handleBlur("name")}
+              placeholder="ルーム名を入力してください"
+            />
+            <Button
+              title="Submit"
+              onPress={() => handleSubmit()}
+              disabled={!isValid || isSubmitting}
+              style={styles.button}
+            />
+          </>
+        )}
+      </Formik>
+    </View>
   );
 }
 

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -1,8 +1,8 @@
 import { StatusBar } from "expo-status-bar";
 import React, { ReactElement, useState, useEffect } from "react";
-import { StyleSheet, View, TextInput } from "react-native";
+import { StyleSheet, View } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { Text } from "react-native-elements";
+import { Input } from "react-native-elements";
 
 const DEFAULT_ENDPOINT = "127.0.0.1";
 export default function HomeScreen(): ReactElement {
@@ -34,8 +34,8 @@ export default function HomeScreen(): ReactElement {
   // TODO ユーザーに関する情報（ユーザーアイコン，ユーザーネーム）の実装
   return (
     <View style={styles.container}>
-      <Text>サーバーアドレス</Text>
-      <TextInput
+      <Input
+        label="サーバーアドレス"
         style={styles.input}
         onChangeText={(input) => setEndpoint(input)}
         value={endpoint}
@@ -52,7 +52,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   input: {
-    width: "50%",
     borderWidth: 1,
     borderColor: "#ccc",
   },

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, View } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Input } from "react-native-elements";
 
-const DEFAULT_ENDPOINT = "127.0.0.1";
+export const DEFAULT_ENDPOINT = "127.0.0.1";
 export default function HomeScreen(): ReactElement {
   const [endpoint, setEndpoint] = useState(DEFAULT_ENDPOINT);
   useEffect(() => {

--- a/src/screens/room-list/index.tsx
+++ b/src/screens/room-list/index.tsx
@@ -8,7 +8,7 @@ import { useIsFocused } from "@react-navigation/native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { DEFAULT_ENDPOINT } from "../home/index";
 
-type Room = { name: string; id: number; num: number };
+type Room = { name: string; id: string; num: number };
 type RoomList = Room[];
 
 export default function RoomListScreen({
@@ -18,10 +18,10 @@ export default function RoomListScreen({
 }): ReactElement {
   const [isLoading, setIsLoading] = useState(true);
   const [displayData, setDisplayData] = useState<RoomList>([]);
-  const [text, setText] = useState("");
+  const [searchInput, setSearchInput] = useState("");
   const isFocused = useIsFocused();
   const [endpoint, setEndPoint] = useState<string>(DEFAULT_ENDPOINT);
-  const [data, setData] = useState<RoomList>([]);
+  const [roomListData, setRoomListData] = useState<RoomList>([]);
   const [updated, setUpdated] = useState(false);
   const websocket = useRef<WebSocket | null>(null);
 
@@ -38,12 +38,11 @@ export default function RoomListScreen({
         console.log(event.data);
         if (event.data.startsWith("{")) {
           const json = JSON.parse(event.data);
-          setData(json.data);
+          setRoomListData(json.data);
         }
       };
       return () => {
         if (websocket.current != null) {
-          console.log("websocket closed");
           websocket.current.close();
         }
       };
@@ -75,13 +74,13 @@ export default function RoomListScreen({
   }, [isFocused]);
 
   useEffect(() => {
-    if (typeof data != "undefined") {
-      setDisplayData(data);
+    if (typeof roomListData != "undefined") {
+      setDisplayData(roomListData);
       setIsLoading(false);
     }
-  }, [data]);
+  }, [roomListData]);
 
-  const handlePress: (id: number) => void = (id) => {
+  const handlePress: (id: string) => void = (id) => {
     if (websocket.current != null) {
       navigation.navigate("Room", { roomid: id, endpoint: endpoint });
     }
@@ -89,8 +88,8 @@ export default function RoomListScreen({
 
   const searchFilter = (text: string) => {
     setIsLoading(true);
-    setText(text);
-    const newData = data.filter((item: Room) => {
+    setSearchInput(text);
+    const newData = roomListData.filter((item: Room) => {
       const itemData = `${item.name.toUpperCase()} ${item.id}`;
 
       const textData = text.toUpperCase();
@@ -151,7 +150,7 @@ export default function RoomListScreen({
         lightTheme
         onChangeText={(text) => searchFilter(text)}
         autoCorrect={false}
-        value={text}
+        value={searchInput}
       />
       {isLoading ? (
         <ActivityIndicator />

--- a/src/screens/room-list/index.tsx
+++ b/src/screens/room-list/index.tsx
@@ -7,8 +7,7 @@ import { FloatingAction } from "react-native-floating-action";
 import { Icon } from "react-native-elements";
 import { useIsFocused } from "@react-navigation/native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-
-const DEFOULT_VALUE = "127.0.0.1";
+import { DEFAULT_ENDPOINT } from "../home/index";
 
 export default function RoomListScreen({
   navigation,
@@ -19,7 +18,7 @@ export default function RoomListScreen({
   const [displayData, setDisplayData] = useState([]);
   const [text, setText] = useState("");
   const isFocused = useIsFocused();
-  const [endpoint, setEndPoint] = useState<string>(DEFOULT_VALUE);
+  const [endpoint, setEndPoint] = useState<string>(DEFAULT_ENDPOINT);
   const [data, setData] = useState([]);
   const [updated, setUpdated] = useState(false);
   const websocket = useRef<WebSocket | null>(null);
@@ -52,10 +51,10 @@ export default function RoomListScreen({
   }, [updated]);
 
   const getEndPoint = async () => {
-    let endpointFromPreferences = DEFOULT_VALUE;
+    let endpointFromPreferences = DEFAULT_ENDPOINT;
     try {
       endpointFromPreferences =
-        (await AsyncStorage.getItem("@endpoint")) || DEFOULT_VALUE;
+        (await AsyncStorage.getItem("@endpoint")) || DEFAULT_ENDPOINT;
     } catch (error) {
       console.log(error);
     } finally {

--- a/src/screens/room-list/index.tsx
+++ b/src/screens/room-list/index.tsx
@@ -90,8 +90,8 @@ export default function RoomListScreen({
   const searchFilter = (text: string) => {
     setIsLoading(true);
     setText(text);
-    const newData = data.filter((item: { name: string }) => {
-      const itemData = `${item.name.toUpperCase()}`;
+    const newData = data.filter((item: Room) => {
+      const itemData = `${item.name.toUpperCase()} ${item.id}`;
 
       const textData = text.toUpperCase();
 

--- a/src/screens/room-list/index.tsx
+++ b/src/screens/room-list/index.tsx
@@ -1,15 +1,15 @@
 import React, { ReactElement, useState, useEffect, useRef } from "react";
 import { StyleSheet, View, FlatList, ActivityIndicator } from "react-native";
-import { SearchBar, ListItem } from "react-native-elements";
+import { SearchBar, ListItem, Icon } from "react-native-elements";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { RootStackParamList } from "../../../App";
 import { FloatingAction } from "react-native-floating-action";
-import { Icon } from "react-native-elements";
 import { useIsFocused } from "@react-navigation/native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { DEFAULT_ENDPOINT } from "../home/index";
 
-type RoomList = { name: string; id: number }[];
+type Room = { name: string; id: number; num: number };
+type RoomList = Room[];
 
 export default function RoomListScreen({
   navigation,
@@ -105,10 +105,9 @@ export default function RoomListScreen({
     setIsLoading(false);
   };
 
-  const keyExtractor = (_item: { name: string; id: number }, index: number) =>
-    index.toString();
+  const keyExtractor = (_item: Room, index: number) => index.toString();
 
-  const renderItem = ({ item }: { item: { name: string; id: number } }) => (
+  const renderItem = ({ item }: { item: Room }) => (
     <ListItem bottomDivider onPress={() => handlePress(item.id)}>
       <ListItem.Content>
         <ListItem.Title style={styles.title}>{item.name}</ListItem.Title>

--- a/src/screens/room-list/index.tsx
+++ b/src/screens/room-list/index.tsx
@@ -31,10 +31,7 @@ export default function RoomListScreen({
       websocket.current.onopen = () => {
         console.log("opened");
         if (websocket.current != null) {
-          console.log("not null");
           websocket.current.send("/list");
-        } else {
-          console.log("null");
         }
       };
       websocket.current.onmessage = (event) => {
@@ -123,7 +120,29 @@ export default function RoomListScreen({
       name: "createRoom",
       position: 1,
     },
+    {
+      text: "Update List",
+      icon: <Icon color="#FFFFFF" type="antdesign" name="reload1" />,
+      name: "updateList",
+      position: 2,
+    },
   ];
+
+  const onPressFloadtingActionIcons = (name: string | undefined) => {
+    switch (name) {
+      case "createRoom":
+        navigation.navigate("CreateRoom", { endpoint: endpoint });
+        break;
+      case "updateList":
+        if (
+          websocket.current != null &&
+          websocket.current.readyState == WebSocket.OPEN
+        ) {
+          websocket.current.send("/list");
+        }
+        break;
+    }
+  };
 
   return (
     <View style={styles.container}>
@@ -144,12 +163,10 @@ export default function RoomListScreen({
         />
       )}
       <FloatingAction
-        overrideWithAction={true}
+        // overrideWithAction={true}
         actions={floadtingActions}
         color={"#03A9F4"}
-        onPressItem={() =>
-          navigation.navigate("CreateRoom", { endpoint: endpoint })
-        }
+        onPressItem={onPressFloadtingActionIcons}
       />
     </View>
   );

--- a/src/screens/room-list/index.tsx
+++ b/src/screens/room-list/index.tsx
@@ -1,5 +1,11 @@
 import React, { ReactElement, useState, useEffect, useRef } from "react";
-import { StyleSheet, View, FlatList, ActivityIndicator } from "react-native";
+import {
+  StyleSheet,
+  SafeAreaView,
+  FlatList,
+  ActivityIndicator,
+  RefreshControl,
+} from "react-native";
 import { SearchBar, ListItem, Icon } from "react-native-elements";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { RootStackParamList } from "../../../App";
@@ -119,32 +125,27 @@ export default function RoomListScreen({
       name: "createRoom",
       position: 1,
     },
-    {
-      text: "Update List",
-      icon: <Icon color="#FFFFFF" type="antdesign" name="reload1" />,
-      name: "updateList",
-      position: 2,
-    },
   ];
+
+  const onRefresh = () => {
+    if (
+      websocket.current != null &&
+      websocket.current.readyState == WebSocket.OPEN
+    ) {
+      websocket.current.send("/list");
+    }
+  };
 
   const onPressFloadtingActionIcons = (name: string | undefined) => {
     switch (name) {
       case "createRoom":
         navigation.navigate("CreateRoom", { endpoint: endpoint });
         break;
-      case "updateList":
-        if (
-          websocket.current != null &&
-          websocket.current.readyState == WebSocket.OPEN
-        ) {
-          websocket.current.send("/list");
-        }
-        break;
     }
   };
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <SearchBar
         placeholder="ルーム検索"
         lightTheme
@@ -159,6 +160,9 @@ export default function RoomListScreen({
           keyExtractor={keyExtractor}
           data={displayData}
           renderItem={renderItem}
+          refreshControl={
+            <RefreshControl refreshing={isLoading} onRefresh={onRefresh} />
+          }
         />
       )}
       <FloatingAction
@@ -167,7 +171,7 @@ export default function RoomListScreen({
         color={"#03A9F4"}
         onPressItem={onPressFloadtingActionIcons}
       />
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/src/screens/room-list/index.tsx
+++ b/src/screens/room-list/index.tsx
@@ -17,7 +17,6 @@ export default function RoomListScreen({
 }): ReactElement {
   const [isLoading, setLoading] = useState(true);
   const [displayData, setDisplayData] = useState([]);
-  const [result, setResult] = useState([]);
   const [text, setText] = useState("");
   const isFocused = useIsFocused();
   const [endpoint, setEndPoint] = useState<string>(DEFOULT_VALUE);
@@ -79,7 +78,6 @@ export default function RoomListScreen({
   useEffect(() => {
     if (typeof data != "undefined") {
       setDisplayData(data);
-      setResult(data);
       setLoading(false);
     }
   }, [data]);
@@ -93,7 +91,7 @@ export default function RoomListScreen({
   const searchFilter = (text: string) => {
     setLoading(true);
     setText(text);
-    const newData = result.filter((item: { name: string }) => {
+    const newData = data.filter((item: { name: string }) => {
       const itemData = `${item.name.toUpperCase()}`;
 
       const textData = text.toUpperCase();

--- a/src/screens/room-list/index.tsx
+++ b/src/screens/room-list/index.tsx
@@ -9,17 +9,19 @@ import { useIsFocused } from "@react-navigation/native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { DEFAULT_ENDPOINT } from "../home/index";
 
+type RoomList = { name: string; id: number }[];
+
 export default function RoomListScreen({
   navigation,
 }: {
   navigation: RoomListScreenNavigationProp;
 }): ReactElement {
   const [isLoading, setIsLoading] = useState(true);
-  const [displayData, setDisplayData] = useState([]);
+  const [displayData, setDisplayData] = useState<RoomList>([]);
   const [text, setText] = useState("");
   const isFocused = useIsFocused();
   const [endpoint, setEndPoint] = useState<string>(DEFAULT_ENDPOINT);
-  const [data, setData] = useState([]);
+  const [data, setData] = useState<RoomList>([]);
   const [updated, setUpdated] = useState(false);
   const websocket = useRef<WebSocket | null>(null);
 
@@ -38,7 +40,8 @@ export default function RoomListScreen({
       websocket.current.onmessage = (event) => {
         console.log(event.data);
         if (event.data.startsWith("{")) {
-          setData(JSON.parse(event.data).data);
+          const json = JSON.parse(event.data);
+          setData(json.data);
         }
       };
       return () => {
@@ -81,9 +84,9 @@ export default function RoomListScreen({
     }
   }, [data]);
 
-  const handlePress: (name: string) => void = (name) => {
+  const handlePress: (id: number) => void = (id) => {
     if (websocket.current != null) {
-      navigation.navigate("Room", { roomname: name, endpoint: endpoint });
+      navigation.navigate("Room", { roomid: id, endpoint: endpoint });
     }
   };
 
@@ -102,14 +105,14 @@ export default function RoomListScreen({
     setIsLoading(false);
   };
 
-  const keyExtractor = (_item: { name: string }, index: number) =>
+  const keyExtractor = (_item: { name: string; id: number }, index: number) =>
     index.toString();
 
-  const renderItem = ({ item }: { item: { name: string } }) => (
-    <ListItem bottomDivider onPress={() => handlePress(item.name)}>
+  const renderItem = ({ item }: { item: { name: string; id: number } }) => (
+    <ListItem bottomDivider onPress={() => handlePress(item.id)}>
       <ListItem.Content>
         <ListItem.Title style={styles.title}>{item.name}</ListItem.Title>
-        {/* <ListItem.Subtitle style={styles.subtitle}>{item.id}</ListItem.Subtitle> */}
+        <ListItem.Subtitle style={styles.subtitle}>{item.id}</ListItem.Subtitle>
       </ListItem.Content>
       <ListItem.Chevron />
     </ListItem>

--- a/src/screens/room-list/index.tsx
+++ b/src/screens/room-list/index.tsx
@@ -15,7 +15,7 @@ export default function RoomListScreen({
 }: {
   navigation: RoomListScreenNavigationProp;
 }): ReactElement {
-  const [isLoading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const [displayData, setDisplayData] = useState([]);
   const [text, setText] = useState("");
   const isFocused = useIsFocused();
@@ -66,7 +66,7 @@ export default function RoomListScreen({
 
   useEffect(() => {
     if (isFocused) {
-      setLoading(true);
+      setIsLoading(true);
       getEndPoint();
     }
     return () => {
@@ -78,7 +78,7 @@ export default function RoomListScreen({
   useEffect(() => {
     if (typeof data != "undefined") {
       setDisplayData(data);
-      setLoading(false);
+      setIsLoading(false);
     }
   }, [data]);
 
@@ -89,7 +89,7 @@ export default function RoomListScreen({
   };
 
   const searchFilter = (text: string) => {
-    setLoading(true);
+    setIsLoading(true);
     setText(text);
     const newData = data.filter((item: { name: string }) => {
       const itemData = `${item.name.toUpperCase()}`;
@@ -100,7 +100,7 @@ export default function RoomListScreen({
     });
 
     setDisplayData(newData);
-    setLoading(false);
+    setIsLoading(false);
   };
 
   const keyExtractor = (_item: { name: string }, index: number) =>

--- a/src/screens/room-list/index.tsx
+++ b/src/screens/room-list/index.tsx
@@ -38,7 +38,7 @@ export default function RoomListScreen({
         console.log(event.data);
         if (event.data.startsWith("{")) {
           const json = JSON.parse(event.data);
-          setRoomListData(json.data);
+          setRoomListData(json.data.rooms);
         }
       };
       return () => {

--- a/src/screens/room/index.tsx
+++ b/src/screens/room/index.tsx
@@ -52,7 +52,7 @@ export default function RoomScreen({
       // イベント受け取り
       websocket.current.onmessage = (event) => {
         console.log("received event:" + event.data);
-        if (event.data.startsWith("{")) {
+        if (event.data.startsWith('{"x')) {
           // TODO サーバ側ですべてjson parsableになるよう実装
           const data = JSON.parse(event.data);
           pan.setValue({ x: data.x, y: data.y });

--- a/src/screens/room/index.tsx
+++ b/src/screens/room/index.tsx
@@ -9,7 +9,7 @@ export default function RoomScreen({
 }: {
   route: RoomScreenRouteProp;
 }): ReactElement {
-  const { roomname, endpoint } = route.params;
+  const { roomid, endpoint } = route.params;
   const pan = useRef(new Animated.ValueXY()).current;
   const websocket = useRef<WebSocket | null>(null);
   const panResponder = useRef(
@@ -36,7 +36,7 @@ export default function RoomScreen({
           websocket.current != null &&
           websocket.current.readyState == WebSocket.OPEN
         ) {
-          websocket.current?.send(JSON.stringify(pan));
+          websocket.current.send(JSON.stringify(pan));
         }
       },
     })
@@ -47,7 +47,7 @@ export default function RoomScreen({
       websocket.current = new WebSocket(`ws://${endpoint}/ws`);
       websocket.current.onopen = () => {
         // ルーム入室
-        websocket.current?.send(`/join ${roomname}`);
+        websocket.current?.send(`/join ${roomid}`);
       };
       // イベント受け取り
       websocket.current.onmessage = (event) => {

--- a/src/screens/room/index.tsx
+++ b/src/screens/room/index.tsx
@@ -32,7 +32,12 @@ export default function RoomScreen({
       onPanResponderRelease: () => {
         pan.flattenOffset();
         // ポジションをjsonとしてサーバに送信
-        websocket.current?.send(JSON.stringify(pan));
+        if (
+          websocket.current != null &&
+          websocket.current.readyState == WebSocket.OPEN
+        ) {
+          websocket.current?.send(JSON.stringify(pan));
+        }
       },
     })
   ).current;

--- a/src/screens/room/index.tsx
+++ b/src/screens/room/index.tsx
@@ -31,10 +31,8 @@ export default function RoomScreen({
       }),
       onPanResponderRelease: () => {
         pan.flattenOffset();
-        if (websocket.current != null) {
-          // ポジションをjsonとしてサーバに送信
-          websocket.current.send(JSON.stringify(pan));
-        }
+        // ポジションをjsonとしてサーバに送信
+        websocket.current?.send(JSON.stringify(pan));
       },
     })
   ).current;
@@ -43,10 +41,8 @@ export default function RoomScreen({
     try {
       websocket.current = new WebSocket(`ws://${endpoint}/ws`);
       websocket.current.onopen = () => {
-        if (websocket.current != null) {
-          // ルーム入室
-          websocket.current.send(`/join ${roomname}`);
-        }
+        // ルーム入室
+        websocket.current?.send(`/join ${roomname}`);
       };
       // イベント受け取り
       websocket.current.onmessage = (event) => {
@@ -55,6 +51,9 @@ export default function RoomScreen({
           // TODO サーバ側ですべてjson parsableになるよう実装
           const data = JSON.parse(event.data);
           pan.setValue({ x: data.x, y: data.y });
+        } else if (event.data == "Someone joined") {
+          // TODO 3人以上のとき、2人以上から送られてくることになり、危険
+          websocket.current?.send(JSON.stringify(pan));
         }
       };
     } catch (error) {


### PR DESCRIPTION
# 概要

ルーム一覧の取得とルーム作成およびルーム入室をgraphQLからwebsocketでできるように変更．

# 動作確認

1. サーバを起動する。[参照](https://github.com/2d-rpg/card-playroom-server/pull/16)
2. 端末を２つ用意し、トップ画面からRoomlistタブを押す。（~~この段階でなぜかリストが表示されない~~）
3. ~~Homeタブを押してもう一度Roomlistタブを押すと~~．ルームリストが表示される。
4. 1つ目の端末でルームリストにあるルームを１つタップすると青い四角が出る。
5. 2つ目の端末で1つ目と同じルームに入ると、端末間で青い四角オブジェクトの位置が同期する。
6. 2つ目の端末でフローティングボタンから新しくルームを作る（自動的にルームに参加する）と、1つ目の端末とは位置が同期しない。

# Updated

- 一発目でリストが表示されるようにする -> [ここ](https://github.com/react-native-async-storage/async-storage/issues/32)を参考に解決 (cf59977)
- ルーム入室時にそのルームにすでに入っている人がいる場合、すでに入っている人の位置と同期させる -> 3人目の場合非効率・危険 (5de9490)
- ルームをルーム名ではなくidで管理＆既に存在するルーム名の場合は作成できないように変更 (097eedc)
- フローティングボタンにルーム一覧更新を追加

<img src="https://user-images.githubusercontent.com/42469701/104456698-65977680-55ec-11eb-9042-3ca98c84a555.gif" alt="alt text" width="500" height="700">

# 関連するサーバーサイドの変更

サーバー側でルームリストをjsonで返すように変更．(https://github.com/2d-rpg/card-playroom-server/pull/16)
